### PR TITLE
Update 'Find' Command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,6 +7,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,10 +1,18 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NATIONALITY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIAL_GROUP;
+
+import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -14,14 +22,20 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose details contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "[" + PREFIX_NAME + "NAME] " + "[" + PREFIX_NAME + "MORE_NAMES] "
+            + "[" + PREFIX_PHONE + "PHONE] " + "[" + PREFIX_PHONE + "MORE_PHONES] "
+            + "[" + PREFIX_EMAIL + "EMAIL] " + "[" + PREFIX_PHONE + "MORE_EMAILS] "
+            + "[" + PREFIX_NATIONALITY + "NATIONALITY] " + "[" + PREFIX_PHONE + "MORE_NATIONALITY] "
+            + "[" + PREFIX_TUTORIAL_GROUP + "TUTORIAL GROUP] " + "[" + PREFIX_PHONE + "MORE_TUTORIAL GROUPS] "
+            + "[" + PREFIX_TAG + "TAG] " + "[" + PREFIX_TAG + "MORE_TAGS]...\n "
+            + "Example: " + COMMAND_WORD + "n/alice p/91234567 tg/19";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private Predicate<Person> predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(Predicate<Person> predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,28 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NATIONALITY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIAL_GROUP;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
+import seedu.address.model.person.MultiplePredicates;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NationalityContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
+import seedu.address.model.person.TutorialGroupContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -16,18 +32,55 @@ public class FindCommandParser implements Parser<FindCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(
+                        args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NATIONALITY,
+                        PREFIX_TUTORIAL_GROUP, PREFIX_TAG);
+
+        ArrayList<Predicate<Person>> predicateList = new ArrayList<>();
+
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()
+            && !argMultimap.getValue(PREFIX_NAME).get().trim().isEmpty()) {
+            List<String> nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
+            predicateList.add(new NameContainsKeywordsPredicate(nameKeywords));
+        }
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()
+            && !argMultimap.getValue(PREFIX_PHONE).get().trim().isEmpty()) {
+            List<String> phoneKeywords = argMultimap.getAllValues(PREFIX_PHONE);
+            predicateList.add(new PhoneContainsKeywordsPredicate(phoneKeywords));
+        }
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()
+            && !argMultimap.getValue(PREFIX_EMAIL).get().trim().isEmpty()) {
+            List<String> emailKeywords = argMultimap.getAllValues(PREFIX_EMAIL);
+            predicateList.add(new EmailContainsKeywordsPredicate(emailKeywords));
+        }
+        if (argMultimap.getValue(PREFIX_NATIONALITY).isPresent()
+            && !argMultimap.getValue(PREFIX_NATIONALITY).get().trim().isEmpty()) {
+            List<String> nationalityKeywords = argMultimap.getAllValues(PREFIX_NATIONALITY);
+            predicateList.add(new NationalityContainsKeywordsPredicate(nationalityKeywords));
+        }
+        if (argMultimap.getValue(PREFIX_TUTORIAL_GROUP).isPresent()
+            && !argMultimap.getValue(PREFIX_TUTORIAL_GROUP).get().trim().isEmpty()) {
+            List<String> tutorialGroupKeywords = argMultimap.getAllValues(PREFIX_TUTORIAL_GROUP);
+            predicateList.add(new TutorialGroupContainsKeywordsPredicate(tutorialGroupKeywords));
+        }
+        if (argMultimap.getValue(PREFIX_TAG).isPresent()
+            && !argMultimap.getValue(PREFIX_TAG).get().trim().isEmpty()) {
+            List<String> tagKeywords = argMultimap.getAllValues(PREFIX_TAG);
+            predicateList.add(new TagContainsKeywordsPredicate(tagKeywords));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        if (predicateList.size() != 0) {
+            MultiplePredicates predicate = new MultiplePredicates(predicateList);
+            return new FindCommand(predicate);
+        }
+        throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
-
 }
+

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -75,12 +75,16 @@ public class FindCommandParser implements Parser<FindCommand> {
             predicateList.add(new TagContainsKeywordsPredicate(tagKeywords));
         }
 
-        if (predicateList.size() != 0) {
+        switch (predicateList.size()) {
+        case (0):
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        case (1):
+            return new FindCommand(predicateList.get(0));
+        default:
             MultiplePredicates predicate = new MultiplePredicates(predicateList);
             return new FindCommand(predicate);
         }
-        throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 }
 

--- a/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
@@ -3,10 +3,8 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
 /**
- * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ * Tests that a {@code Person}'s {@code Email} matches any of the keywords given.
  */
 public class EmailContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
@@ -18,7 +16,8 @@ public class EmailContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword));
+                .anyMatch(keyword -> person.getEmail().value.toLowerCase()
+                .contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ */
+public class EmailContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public EmailContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof EmailContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((EmailContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/MultiplePredicates.java
+++ b/src/main/java/seedu/address/model/person/MultiplePredicates.java
@@ -1,0 +1,39 @@
+package seedu.address.model.person;
+
+import java.util.ArrayList;
+import java.util.function.Predicate;
+
+/**
+ * Combine two or more Predicates together.
+ */
+public class MultiplePredicates implements Predicate<Person> {
+
+    private final ArrayList<Predicate<Person>> predicateList;
+
+    public MultiplePredicates(ArrayList<Predicate<Person>> predicateList) {
+        this.predicateList = predicateList;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return predicateList
+                .stream()
+                .anyMatch(predicate -> predicate.test(person));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        ArrayList<Predicate<Person>> firstPredicate = this.predicateList;
+        ArrayList<Predicate<Person>> secondPredicate = ((MultiplePredicates) other).predicateList;
+
+        //Careful!! O(n^2) operation. Can be improved to O(nlogn) with sorting.
+        boolean equalList = (firstPredicate.size() == secondPredicate.size())
+                        && firstPredicate.containsAll(secondPredicate)
+                        && secondPredicate.containsAll(firstPredicate);
+
+        return other == this // short circuit if same object
+                || (other instanceof MultiplePredicates // instanceof handles nulls
+                && equalList); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -3,8 +3,6 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  */
@@ -18,7 +16,8 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> person.getName().fullName.toLowerCase()
+                .contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NationalityContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NationalityContainsKeywordsPredicate.java
@@ -3,11 +3,8 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
-
 /**
- * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ * Tests that a {@code Person}'s {@code Nationality} matches any of the keywords given.
  */
 public class NationalityContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
@@ -19,7 +16,8 @@ public class NationalityContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getNationality().value, keyword));
+                .anyMatch(keyword -> person.getNationality().value.toLowerCase()
+                .contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NationalityContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NationalityContainsKeywordsPredicate.java
@@ -1,0 +1,32 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+
+/**
+ * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ */
+public class NationalityContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public NationalityContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getNationality().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof NationalityContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((NationalityContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -1,0 +1,33 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+
+
+/**
+ * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ */
+public class PhoneContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public PhoneContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PhoneContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((PhoneContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -3,10 +3,6 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
-
-
 /**
  * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
  */
@@ -20,7 +16,8 @@ public class PhoneContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword));
+                .anyMatch(keyword -> person.getPhone().value.toLowerCase()
+                .contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -3,11 +3,8 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
-
 /**
- * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ * Tests that a {@code Person}'s {@code Tag} matches any of the keywords given.
  */
 public class TagContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
@@ -20,8 +17,9 @@ public class TagContainsKeywordsPredicate implements Predicate<Person> {
     public boolean test(Person person) {
         return keywords.stream()
                 .anyMatch(keyword -> person.getTags().stream()
-                .anyMatch(tag -> StringUtil.containsWordIgnoreCase(tag.tagName, keyword))
-                );
+                .anyMatch(tag -> tag.tagName.toLowerCase()
+                .contains(keyword.toLowerCase()
+                )));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -1,0 +1,34 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+
+/**
+ * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ */
+public class TagContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public TagContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> person.getTags().stream()
+                .anyMatch(tag -> StringUtil.containsWordIgnoreCase(tag.tagName, keyword))
+                );
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TagContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/TutorialGroupContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TutorialGroupContainsKeywordsPredicate.java
@@ -1,0 +1,32 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+
+/**
+ * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ */
+public class TutorialGroupContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public TutorialGroupContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getTutorialGroup().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TutorialGroupContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TutorialGroupContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/TutorialGroupContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TutorialGroupContainsKeywordsPredicate.java
@@ -3,11 +3,8 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
-
 /**
- * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ * Tests that a {@code Person}'s {@code Tutorial Group} matches any of the keywords given.
  */
 public class TutorialGroupContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
@@ -19,7 +16,8 @@ public class TutorialGroupContainsKeywordsPredicate implements Predicate<Person>
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getTutorialGroup().value, keyword));
+                .anyMatch(keyword -> person.getTutorialGroup().value.toLowerCase()
+                .contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -19,7 +20,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -39,7 +46,7 @@ public class LogicManagerTest {
     @TempDir
     public Path temporaryFolder;
 
-    private Model model = new ModelManager();
+    private final Model model = new ModelManager();
     private Logic logic;
 
     @BeforeEach
@@ -52,21 +59,93 @@ public class LogicManagerTest {
     }
 
     @Test
+    public void execute_emptyCommand_throwsParseException() {
+        String emptyCommand = " ";
+        String helpMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE);
+        assertParseException(emptyCommand, helpMessage);
+    }
+
+    @Test
+    public void execute_nonEnglish_throwsParseException() {
+        String emptyCommand = "한글你好";
+        assertParseException(emptyCommand, MESSAGE_UNKNOWN_COMMAND);
+    }
+
+    @Test
+    public void execute_emoji_throwsParseException() {
+        String emptyCommand = "\uD83D\uDE3E";
+        assertParseException(emptyCommand, MESSAGE_UNKNOWN_COMMAND);
+    }
+
+    @Test
+    public void execute_specialChars_throwsParseException() {
+        String emptyCommand = "\\/!@#$%^&()_+{}:<>?";
+        assertParseException(emptyCommand, MESSAGE_UNKNOWN_COMMAND);
+    }
+
+
+    @Test
     public void execute_invalidCommandFormat_throwsParseException() {
         String invalidCommand = "uicfhmowqewca";
         assertParseException(invalidCommand, MESSAGE_UNKNOWN_COMMAND);
     }
 
     @Test
-    public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    public void execute_addCommand_throwsParseException() {
+        String addCommand = AddCommand.COMMAND_WORD;
+        String addMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+        assertParseException(addCommand, addMessage);
+    }
+
+    @Test
+    public void execute_clearCommand_success() throws Exception {
+        String clearCommand = ClearCommand.COMMAND_WORD;
+        assertCommandSuccess(clearCommand, ClearCommand.MESSAGE_SUCCESS, model);
+    }
+
+    @Test
+    public void execute_deleteCommand_throwsParseException() {
+        String deleteCommand = DeleteCommand.COMMAND_WORD;
+        String deleteMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE);
+        assertParseException(deleteCommand, deleteMessage);
+    }
+
+    @Test
+    public void execute_editCommand_throwsParseException() {
+        String editCommand = EditCommand.COMMAND_WORD;
+        String editMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
+        assertParseException(editCommand, editMessage);
+    }
+
+    @Test
+    public void execute_exitCommand_throwsParseException() throws Exception {
+        String exitCommand = ExitCommand.COMMAND_WORD;
+        assertCommandSuccess(exitCommand, ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEMENT, model);
+    }
+
+    @Test
+    public void execute_findCommand_throwsParseException() {
+        String findCommand = FindCommand.COMMAND_WORD;
+        String findMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE);
+        assertParseException(findCommand, findMessage);
+    }
+
+    @Test
+    public void execute_helpCommand_success() throws Exception {
+        String helpCommand = HelpCommand.COMMAND_WORD;
+        assertCommandSuccess(helpCommand, HelpCommand.SHOWING_HELP_MESSAGE, model);
     }
 
     @Test
     public void execute_validCommand_success() throws Exception {
         String listCommand = ListCommand.COMMAND_WORD;
         assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
+    }
+
+    @Test
+    public void execute_commandExecutionError_throwsCommandException() {
+        String deleteCommand = "delete 9";
+        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
@@ -104,7 +183,7 @@ public class LogicManagerTest {
     private void assertCommandSuccess(String inputCommand, String expectedMessage,
             Model expectedModel) throws CommandException, ParseException {
         CommandResult result = logic.execute(inputCommand);
-        assertEquals(expectedMessage, result.getFeedbackToUser());
+        assertEquals(expectedMessage, ((CommandResult) result).getFeedbackToUser());
         assertEquals(expectedModel, model);
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -59,7 +59,7 @@ public class CommandTestUtil {
     public static final String INVALID_NATIONALITY_DESC = " "
             + PREFIX_NATIONALITY; // empty string not allowed for nationality
     public static final String INVALID_TUTORIAL_GROUP_DESC = " "
-            + PREFIX_TUTORIAL_GROUP + "B"; // 'B' not allowed in tutorial groups
+            + PREFIX_TUTORIAL_GROUP + "B"; // Alphabets not allowed in tutorial groups
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -18,7 +18,9 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -29,10 +31,10 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        PhoneContainsKeywordsPredicate firstPredicate =
+                new PhoneContainsKeywordsPredicate(Collections.singletonList("first"));
+        PhoneContainsKeywordsPredicate secondPredicate =
+                new PhoneContainsKeywordsPredicate(Collections.singletonList("second"));
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -57,7 +59,7 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        EmailContainsKeywordsPredicate predicate = prepareEmailPredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -67,7 +69,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -77,7 +79,14 @@ public class FindCommandTest {
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
+    private NameContainsKeywordsPredicate prepareNamePredicate(String userInput) {
         return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code EmailContainsKeywordsPredicate}.
+     */
+    private EmailContainsKeywordsPredicate prepareEmailPredicate(String userInput) {
+        return new EmailContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -7,8 +7,10 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
@@ -23,8 +25,11 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
+import seedu.address.model.person.MultiplePredicates;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -70,10 +75,15 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        List<String> keywords = Arrays.asList("n/foo", "e/bar@a.com", "t/baz");
+        MultiplePredicates predicate = new MultiplePredicates(new ArrayList<Predicate<Person>>(List.of(
+                new NameContainsKeywordsPredicate(List.of("foo")),
+                new EmailContainsKeywordsPredicate(List.of("bar@a.com")),
+                new TagContainsKeywordsPredicate(List.of("baz"))
+        )));
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        assertEquals(new FindCommand(predicate), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -28,8 +28,11 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.MultiplePredicates;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NationalityContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 import seedu.address.model.person.TagContainsKeywordsPredicate;
+import seedu.address.model.person.TutorialGroupContainsKeywordsPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -74,11 +77,74 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("n/foo", "e/bar@a.com", "t/baz");
+    public void parseCommand_findNamePredicate() throws Exception {
+        List<String> keywords = Arrays.asList("n/Mario");
+        NameContainsKeywordsPredicate predicate =
+                new NameContainsKeywordsPredicate(List.of("Mario"));
+        FindCommand command = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(predicate), command);
+    }
+
+    @Test
+    public void parseCommand_findPhonePredicate() throws Exception {
+        List<String> keywords = Arrays.asList("p/995999");
+        PhoneContainsKeywordsPredicate predicate =
+                new PhoneContainsKeywordsPredicate(List.of("995999"));
+        FindCommand command = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(predicate), command);
+    }
+
+    @Test
+    public void parseCommand_findEmailPredicate() throws Exception {
+        List<String> keywords = Arrays.asList("e/acbar@rabca.com");
+        EmailContainsKeywordsPredicate predicate =
+                new EmailContainsKeywordsPredicate(List.of("acbar@rabca.com"));
+        FindCommand command = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(predicate), command);
+    }
+
+    @Test
+    public void parseCommand_findNationalityPredicate() throws Exception {
+        List<String> keywords = Arrays.asList("nat/North Korea");
+        NationalityContainsKeywordsPredicate predicate =
+                new NationalityContainsKeywordsPredicate(List.of("North Korea"));
+        FindCommand command = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(predicate), command);
+    }
+
+    @Test
+    public void parseCommand_findTutorialGroupPredicate() throws Exception {
+        List<String> keywords = Arrays.asList("tg/123456789");
+        TutorialGroupContainsKeywordsPredicate predicate =
+                new TutorialGroupContainsKeywordsPredicate(List.of("123456789"));
+        FindCommand command = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(predicate), command);
+    }
+
+    @Test
+    public void parseCommand_findTagPredicate() throws Exception {
+        List<String> keywords = Arrays.asList("t/Wowz");
+        TagContainsKeywordsPredicate predicate =
+                new TagContainsKeywordsPredicate(List.of("Wowz"));
+        FindCommand command = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(predicate), command);
+    }
+
+    @Test
+    public void parseCommand_findMultiplePredicates() throws Exception {
+        List<String> keywords = Arrays.asList("n/foo", "p/999", "e/bar@a.com", "nat/DPRK", "tg/420", "t/baz");
         MultiplePredicates predicate = new MultiplePredicates(new ArrayList<Predicate<Person>>(List.of(
                 new NameContainsKeywordsPredicate(List.of("foo")),
+                new PhoneContainsKeywordsPredicate(List.of("999")),
                 new EmailContainsKeywordsPredicate(List.of("bar@a.com")),
+                new NationalityContainsKeywordsPredicate(List.of("DPRK")),
+                new TutorialGroupContainsKeywordsPredicate(List.of("420")),
                 new TagContainsKeywordsPredicate(List.of("baz"))
         )));
         FindCommand command = (FindCommand) parser.parseCommand(

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -4,12 +4,19 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.person.MultiplePredicates;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NationalityContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.TutorialGroupContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -22,13 +29,20 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
+        MultiplePredicates predicate = new MultiplePredicates(new ArrayList<Predicate<Person>>(List.of(
+                new NameContainsKeywordsPredicate(List.of("Alice")),
+                new PhoneContainsKeywordsPredicate(List.of("91234456")),
+                new NationalityContainsKeywordsPredicate(List.of("MY")),
+                new TutorialGroupContainsKeywordsPredicate(List.of("19"))
+        )));
+
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+                new FindCommand(predicate);
+        assertParseSuccess(parser, " n/Alice p/91234456 nat/MY tg/19", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, " \n n/Alice \n \t p/91234456 \n \t nat/MY \n \t tg/19 \t", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/model/person/EmailContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/EmailContainsKeywordsPredicateTest.java
@@ -1,0 +1,78 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class EmailContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("a@b.com");
+        List<String> secondPredicateKeywordList = Arrays.asList("b@c.abc", "abc@bcdfsdf.dsfsdf");
+
+        EmailContainsKeywordsPredicate firstPredicate = new EmailContainsKeywordsPredicate(firstPredicateKeywordList);
+        EmailContainsKeywordsPredicate secondPredicate = new EmailContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        EmailContainsKeywordsPredicate firstPredicateCopy =
+                new EmailContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_emailContainsKeywords_returnsTrue() {
+        // One keyword
+        EmailContainsKeywordsPredicate predicate =
+                new EmailContainsKeywordsPredicate(Collections.singletonList("hibro@hotmail.com"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("hibro@hotmail.com").build()));
+
+        // Only one matching keyword
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("hibro@hotmail.com", "hisis@gmail.com"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("hisis@gmail.com").build()));
+
+        // Mixed-case keyword
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("hIbRo@HoTmAiL.CoM"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("hibro@hotmail.com").build()));
+
+        // Multiple keywords
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("hibro@hotmail.com", "hisis@gmail.com"));
+        assertTrue(predicate.test(new PersonBuilder().withEmail("hibro@hotmail.comhisisgmail.com").build()));
+    }
+
+    @Test
+    public void test_emailDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        EmailContainsKeywordsPredicate predicate = new EmailContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withEmail("hibro@hotmail.com").build()));
+
+        // Non-matching keyword
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("hibro@hotmail.com"));
+        assertFalse(predicate.test(new PersonBuilder().withEmail("hisis@gmail.com").build()));
+
+        // Keywords match phone, email and nationality, but does not match name
+        predicate = new EmailContainsKeywordsPredicate(Arrays.asList("alice@email.com"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Amy Bee").withPhone("12345")
+                .withEmail("alice1@email.com").withNationality("North Korea").withTutorialGroup("19")
+                .withTags("Meh").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/NationalityContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NationalityContainsKeywordsPredicateTest.java
@@ -1,0 +1,82 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class NationalityContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("Malaysia");
+        List<String> secondPredicateKeywordList = Arrays.asList("Singapore", "Korea, North");
+
+        NationalityContainsKeywordsPredicate firstPredicate =
+                new NationalityContainsKeywordsPredicate(firstPredicateKeywordList);
+        NationalityContainsKeywordsPredicate secondPredicate =
+                new NationalityContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        NationalityContainsKeywordsPredicate firstPredicateCopy =
+                new NationalityContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nationalityContainsKeywords_returnsTrue() {
+        // One keyword
+        NationalityContainsKeywordsPredicate predicate =
+                new NationalityContainsKeywordsPredicate(Collections.singletonList("SG"));
+        assertTrue(predicate.test(new PersonBuilder().withNationality("SG").build()));
+
+        // Multiple keywords
+        predicate = new NationalityContainsKeywordsPredicate(Arrays.asList("SG", "MY"));
+        assertTrue(predicate.test(new PersonBuilder().withNationality("SG").build()));
+
+        // Mixed-case keyword
+        predicate = new NationalityContainsKeywordsPredicate(Arrays.asList("SG"));
+        assertTrue(predicate.test(new PersonBuilder().withNationality("sg").build()));
+
+        // Only one matching keyword
+        predicate = new NationalityContainsKeywordsPredicate(Arrays.asList("SG", "MY"));
+        assertTrue(predicate.test(new PersonBuilder().withNationality("SGMY").build()));
+    }
+
+    @Test
+    public void test_nationalityDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        NationalityContainsKeywordsPredicate predicate =
+                new NationalityContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withNationality("SG").build()));
+
+        // Non-matching keyword
+        predicate = new NationalityContainsKeywordsPredicate(Arrays.asList("SG"));
+        assertFalse(predicate.test(new PersonBuilder().withNationality("MY").build()));
+
+        // Keywords match phone, email and nationality, but does not match name
+        predicate = new NationalityContainsKeywordsPredicate(
+                Arrays.asList("12345", "alice@email.com", "Main", "Street"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Amy Bee").withPhone("12345")
+                .withEmail("alice@email.com").withNationality("North Korea").withTutorialGroup("19")
+                .withTags("Meh").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/PhoneContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneContainsKeywordsPredicateTest.java
@@ -1,0 +1,70 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class PhoneContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("912345567");
+        List<String> secondPredicateKeywordList = Arrays.asList("999", "9876543210");
+
+        PhoneContainsKeywordsPredicate firstPredicate = new PhoneContainsKeywordsPredicate(firstPredicateKeywordList);
+        PhoneContainsKeywordsPredicate secondPredicate = new PhoneContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        PhoneContainsKeywordsPredicate firstPredicateCopy =
+                new PhoneContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_phoneContainsKeywords_returnsTrue() {
+        // One keyword
+        PhoneContainsKeywordsPredicate predicate =
+                new PhoneContainsKeywordsPredicate(Collections.singletonList("912345"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("912345").build()));
+
+        // Only one matching keyword
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("9123456", "908976"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("908976").build()));
+
+        // Non-matching keyword
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("908976", "9123456"));
+        assertTrue(predicate.test(new PersonBuilder().withPhone("9123456908976").build()));
+    }
+
+    @Test
+    public void test_phoneDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        PhoneContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withPhone("908976").build()));
+
+        // Keywords does not match name
+        predicate = new PhoneContainsKeywordsPredicate(Arrays.asList("12345", "123452354", "12345235", "12345253"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Amy Bee").withPhone("94354")
+                .withEmail("alice@email.com").withNationality("North Korea").withTutorialGroup("19")
+                .withTags("Meh").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/TagContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/TagContainsKeywordsPredicateTest.java
@@ -1,0 +1,76 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class TagContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("Yes");
+        List<String> secondPredicateKeywordList = Arrays.asList("No", "Maybe");
+
+        TagContainsKeywordsPredicate firstPredicate = new TagContainsKeywordsPredicate(firstPredicateKeywordList);
+        TagContainsKeywordsPredicate secondPredicate = new TagContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TagContainsKeywordsPredicate firstPredicateCopy = new TagContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_tagContainsKeywords_returnsTrue() {
+        // One keyword
+        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Collections.singletonList("Yes"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("Yes").build()));
+
+        // Multiple keywords
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("Yes", "No"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("Yes").build()));
+
+        // Mixed-case keyword
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("YES"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("yes").build()));
+
+        // Only one matching keyword
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("Yes", "No"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("YesNo").build()));
+    }
+
+    @Test
+    public void test_tagDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        TagContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withTags("Yes").build()));
+
+        // Non-matching keyword
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("Yes"));
+        assertFalse(predicate.test(new PersonBuilder().withTags("No").build()));
+
+        // Keywords match phone, email and nationality, but does not match name
+        predicate = new TagContainsKeywordsPredicate(Arrays.asList("Yes", "No", "Maybe"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Amy Bee").withPhone("12345")
+                .withEmail("alice@email.com").withNationality("North Korea").withTutorialGroup("19")
+                .withTags("Meh").build()));
+    }
+}

--- a/src/test/java/seedu/address/model/person/TutorialGroupContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/TutorialGroupContainsKeywordsPredicateTest.java
@@ -1,0 +1,74 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class TutorialGroupContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("912345567");
+        List<String> secondPredicateKeywordList = Arrays.asList("999", "9876543210");
+
+        TutorialGroupContainsKeywordsPredicate firstPredicate =
+                new TutorialGroupContainsKeywordsPredicate(firstPredicateKeywordList);
+        TutorialGroupContainsKeywordsPredicate secondPredicate =
+                new TutorialGroupContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TutorialGroupContainsKeywordsPredicate firstPredicateCopy =
+                new TutorialGroupContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_tutorialGroupContainsKeywords_returnsTrue() {
+        // One keyword
+        TutorialGroupContainsKeywordsPredicate predicate =
+                new TutorialGroupContainsKeywordsPredicate(Collections.singletonList("912345"));
+        assertTrue(predicate.test(new PersonBuilder().withTutorialGroup("912345").build()));
+
+        // Only one matching keyword
+        predicate = new TutorialGroupContainsKeywordsPredicate(Arrays.asList("9123456", "908976"));
+        assertTrue(predicate.test(new PersonBuilder().withTutorialGroup("908976").build()));
+
+        // Non-matching keyword
+        predicate = new TutorialGroupContainsKeywordsPredicate(Arrays.asList("908976", "9123456"));
+        assertTrue(predicate.test(new PersonBuilder().withTutorialGroup("9123456908976").build()));
+    }
+
+    @Test
+    public void test_tutorialGroupDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        TutorialGroupContainsKeywordsPredicate predicate =
+                new TutorialGroupContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withTutorialGroup("908976").build()));
+
+        // Keywords does not match name
+        predicate = new TutorialGroupContainsKeywordsPredicate(
+                Arrays.asList("99999", "123452354", "12345235", "12345253"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Amy Bee").withPhone("12345")
+                .withEmail("alice@email.com").withNationality("North Korea").withTutorialGroup("19")
+                .withTags("Meh").build()));
+    }
+}


### PR DESCRIPTION
The previous 'Find' command can only support multiple 'Name' keywords.

We want Socius to support all properties (e.g. 'Social', 'Tutorial Group', etc)

This commit implements an updated 'Find' command that supports multiple keywords of any properties. The format follows 'Add' and 'Edit'. A 'MultipleParsers' class was implemented to easily track how many of what Predicates are in use in a 'Find' command.