### PR TITLE
Fix path to image resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveName = 'addressbook.jar'
+    archiveName = 'Socius.jar'
 }
 
 run {

--- a/src/main/java/seedu/address/storage/ImageStorage.java
+++ b/src/main/java/seedu/address/storage/ImageStorage.java
@@ -1,13 +1,15 @@
 package seedu.address.storage;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-
 import javafx.scene.image.Image;
+import seedu.address.MainApp;
 
 public class ImageStorage {
 
-    private static final String IMAGE_RESOURCE_PATH = "src/main/resources/images/";
+    private static final String IMAGE_RESOURCE_PATH = "/images/";
+
+    private static Image getImage(String imagePath) {
+        return new Image(MainApp.class.getResourceAsStream(imagePath));
+    }
 
     /**
      * Returns a social platform icon given a platform.
@@ -19,6 +21,8 @@ public class ImageStorage {
         case "ig":
             imageFile = "instagram.png";
             break;
+        case "tl":
+            //Fallthrough
         case "tg":
             imageFile = "telegram.png";
             break;
@@ -51,13 +55,7 @@ public class ImageStorage {
         default:
             return null;
         }
-        try {
-            FileInputStream inputStream = new FileInputStream(IMAGE_RESOURCE_PATH + "social/" + imageFile);
-            return new Image(inputStream);
-        } catch (FileNotFoundException e) {
-            System.out.println("Image file not found for social platform: " + platform);
-        }
-        return null;
+        return getImage(IMAGE_RESOURCE_PATH + "social/" + imageFile);
     }
 
     /**
@@ -76,15 +74,7 @@ public class ImageStorage {
         default:
             return null;
         }
-        try {
-            FileInputStream inputStream = new FileInputStream(IMAGE_RESOURCE_PATH + "gender/" + imageFile);
-            return new Image(inputStream);
-        } catch (FileNotFoundException e) {
-            System.out.println("Image file not found for gender: " + gender);
-        }
-        return null;
+        return getImage(IMAGE_RESOURCE_PATH + "gender/" + imageFile);
     }
 
 }
-
-


### PR DESCRIPTION
Previously, the path to images do not work in `.jar`. It has been now fixed.