### PR TITLE
Fix Phone Number Constraints & Review Remark Prefix Constraints

### DIFF
--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -12,7 +12,7 @@ public class Phone {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+    public static final String VALIDATION_REGEX = "\\d{3,15}";
     public final String value;
 
     /**

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -11,8 +11,9 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,15}";
+            "Phone numbers should only contain numbers and optionally start with a  '+'. "
+            + "Phone numbers should be at least 3 digits and at most 15 digits long.";
+    public static final String VALIDATION_REGEX = "\\+?\\d{3,15}";
     public final String value;
 
     /**

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -27,7 +27,7 @@ import seedu.address.model.tag.Tag;
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_GENDER = "N";
-    private static final String INVALID_PHONE = "+651234";
+    private static final String INVALID_PHONE = "@651234";
     private static final String INVALID_NATIONALITY = "SoCIAN";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TUTORIAL_GROUP = "B";
@@ -35,7 +35,7 @@ public class ParserUtilTest {
     private static final String INVALID_TAG = "#friend";
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_GENDER = "M";
-    private static final String VALID_PHONE = "123456";
+    private static final String VALID_PHONE = "+123456";
     private static final String VALID_NATIONALITY = "Vietnamese";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TUTORIAL_GROUP = "T09";

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -25,12 +25,16 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
         assertFalse(Phone.isValidPhone("1242938420331231")); // more than 15 digits
-
+        assertFalse(Phone.isValidPhone("+")); // + only
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
         assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers, 15 digits
         assertTrue(Phone.isValidPhone("")); // empty string
+        assertTrue(Phone.isValidPhone("+911")); // + with 3 numbers
+        assertTrue(Phone.isValidPhone("+124293842033123")); // + with 15 numbers
+
+
     }
 }

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -24,11 +24,13 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("1242938420331231")); // more than 15 digits
+
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers, 15 digits
         assertTrue(Phone.isValidPhone("")); // empty string
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -24,7 +24,7 @@ import seedu.address.model.person.TutorialGroup;
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_GENDER = "N";
-    private static final String INVALID_PHONE = "+651234";
+    private static final String INVALID_PHONE = "@651234";
     private static final String INVALID_NATIONALITY = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TUTORIAL_GROUP = "A";


### PR DESCRIPTION
Phone Number:
There is no upper limit of the length of phone number.

According to @luminousleek, long phone number should not be accepted. [Valid point]. 
Also, signs like "+" and "-" should be accepted. [I don't think - should be accepted since the format differs from country to country. In terms of implementation, a lot of testing is needed to make sure the - is not used wrongly e.g. "-9-1-2-3-4-5-6-7-"]

I have tweaked the phone number to accept up to 15 numbers. The longest phone number in the world is 15 numbers (India's phone number with country code). Phone number can also optionally start with '+'

Remark:
According to @xianlinc, Remark can accept invalid prefix. [Technically not a bug. Already stated in the UG that Remark accepts all string after "r/". Imagine the user wants to input '_r/ Favourite pastime: Likes to Travel!! \\(^_^)/hehe_', I see no reason to reject this.]

I think we can close that issue.