### PR TITLE
Plenty of Small Bug Fixes

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -6,7 +6,7 @@ package seedu.address.commons.core;
 public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command. ";
-    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n\n%1$s";
 
     // List Command
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";

--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -19,7 +19,6 @@ public class Index {
         if (zeroBasedIndex < 0) {
             throw new IndexOutOfBoundsException();
         }
-
         this.zeroBasedIndex = zeroBasedIndex;
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -22,7 +22,7 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book.\n"
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + "[" + PREFIX_GENDER + "GENDER] "
@@ -33,7 +33,7 @@ public class AddCommand extends Command {
             + "[" + PREFIX_REMARK + "REMARK] "
             + "[" + PREFIX_SOCIAL_HANDLE + "SOCIAL HANDLE]... "
             + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Note: "
+            + "Note:\n"
             + " - Parameters in square brackets are optional.\n"
             + " - Parameters followed by ... can be used more than once.\n"
             + "Example: " + COMMAND_WORD + " "

--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -31,14 +31,18 @@ public class AddTagCommand extends Command {
 
     public static final String COMMAND_WORD = "addt";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": "
-            + "'addt all t/TAG' adds tags for everyone. "
-            + "'addt INDEX t/TAG' adds tags for selected person."
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Add tags to people.\n"
+            + " - 'addt all t/TAG' adds tags for everyone.\n"
+            + " - 'addt INDEX t/TAG' adds tags for the person identified by the index number used in the displayed "
+            + "person list.\n"
             + "Parameters: "
-            + "INDEX (must be a positive integer or the word 'all')"
-            + "" + PREFIX_TAG + "TAG...\n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_TAG + "CS2103 Group Mate ";
+            + "INDEX (must be a positive integer or the word 'all') "
+            + PREFIX_TAG + "TAG...\n"
+            + "Note:\n"
+            + " - Tags must be alphanumeric.\n"
+            + "Example: "
+            + COMMAND_WORD + " 1 "
+            + PREFIX_TAG + "CS2103Teammate";
 
     public static final String MESSAGE_ADD_TAG_SUCCESS = "Added Tag: %1$s";
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";

--- a/src/main/java/seedu/address/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AliasCommand.java
@@ -21,7 +21,8 @@ public class AliasCommand extends Command {
             + ": Creates a shortcut name for a command.\n"
             + "Parameters: "
             + PREFIX_ALIAS + "ALIAS "
-            + PREFIX_COMMAND + "COMMAND ";
+            + PREFIX_COMMAND + "COMMAND\n"
+            + "Example: a/findPartner c/ g/m nat/Korean";
 
     public static final String MESSAGE_SUCCESS = "Alias successfully added. Mapped `%s` to the command `%s`.";
     public static final String MESSAGE_INVALID_ALIAS = "Invalid alias. Command words cannot be used as an alias.";

--- a/src/main/java/seedu/address/logic/commands/DeleteMultipleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteMultipleCommand.java
@@ -2,9 +2,12 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GENDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NATIONALITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SOCIAL_HANDLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIAL_GROUP;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
@@ -24,16 +27,21 @@ public class DeleteMultipleCommand extends Command {
 
     public static final String COMMAND_WORD = "deletem";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes all persons whose details contain any of "
-            + "the specified keywords (case-insensitive) from the list.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "[" + PREFIX_NAME + "NAME] " + "[" + PREFIX_NAME + "MORE_NAMES] "
-            + "[" + PREFIX_PHONE + "PHONE] " + "[" + PREFIX_PHONE + "MORE_PHONES] "
-            + "[" + PREFIX_EMAIL + "EMAIL] " + "[" + PREFIX_PHONE + "MORE_EMAILS] "
-            + "[" + PREFIX_NATIONALITY + "NATIONALITY] " + "[" + PREFIX_PHONE + "MORE_NATIONALITY] "
-            + "[" + PREFIX_TUTORIAL_GROUP + "TUTORIAL GROUP] " + "[" + PREFIX_PHONE + "MORE_TUTORIAL GROUPS] "
-            + "[" + PREFIX_TAG + "TAG] " + "[" + PREFIX_TAG + "MORE_TAGS]...\n "
-            + "Example: " + COMMAND_WORD + " n/alice p/91234567 tg/19";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes all persons whose details contain every "
+            + "specified keywords.\n"
+            + "Parameters: "
+            + "[" + PREFIX_NAME + "NAME]... "
+            + "[" + PREFIX_GENDER + "GENDER]... "
+            + "[" + PREFIX_PHONE + "PHONE]... "
+            + "[" + PREFIX_EMAIL + "EMAIL]... "
+            + "[" + PREFIX_NATIONALITY + "NATIONALITY]... "
+            + "[" + PREFIX_TUTORIAL_GROUP + "TUTORIAL GROUP]... "
+            + "[" + PREFIX_REMARK + "REMARK]... "
+            + "[" + PREFIX_SOCIAL_HANDLE + "SOCIAL HANDLE]... "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Note:\n"
+            + " - Keywords are case-insensitive"
+            + "Example:  " + COMMAND_WORD + " n/alice p/91234567 tg/19";
 
     private int startIndex;
     private int endIndex;

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -32,16 +32,18 @@ public class DeleteTagCommand extends Command {
 
     public static final String COMMAND_WORD = "deletet";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Delete tags of persons in the current list. "
-            + "'deletet all' deletes all tags of everyone."
-            + "'deletet INDEX' deletes all tags of selected person."
-            + "'deletet all [t/TAG1 t/TAG2...]' deletes selected tags for everyone."
-            + "'deletet INDEX [t/TAG1 t/TAG2...]' deletes selected tags for selected person"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Delete tags of persons in the displayed list.\n"
+            + " - 'deletet all' deletes all tags for everyone.\n"
+            + " - 'deletet INDEX' deletes all tags for the person identified by the index number used in the displayed "
+            + "person list.\n"
+            + " - 'deletet all [t/TAG1 t/TAG2...]' deletes the specified tags for everyone."
+            + " - 'deletet INDEX [t/TAG1 t/TAG2...]' deletes the specified tags for the person identified by the index "
+            + "number used in the displayed person list.\n"
             + "Parameters: "
             + "INDEX (must be a positive integer or the word 'all') "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_TAG + "CS2103 Group Mate ";
+            + PREFIX_TAG + "CS2103Teammate";
 
     public static final String MESSAGE_DELETED_ALL_TAG_SUCCESS = "Deleted All Tags.";
     public static final String MESSAGE_DELETED_TAG_SUCCESS = "Deleted Tag: %1$s";

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -21,9 +21,9 @@ public class ExportCommand extends Command {
     public static final String COMMAND_WORD = "export";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Exports a file identified by the given filename.\n"
+            + ": Exports the current contacts list into a file identified by the given filename.\n"
             + "Parameters: FILE_NAME\n"
-            + "Example: " + COMMAND_WORD + " class.json";
+            + "Example: " + COMMAND_WORD + " friends.json";
 
     public static final String MESSAGE_SUCCESS = "File successfully exported as JSON format to %s";
     public static final String MESSAGE_IO_ERROR =

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -25,8 +25,8 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose details contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose details contain every "
+            + "specified keywords and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "[" + PREFIX_NAME + "NAME] " + "[" + PREFIX_NAME + "MORE_NAMES] "
             + "[" + PREFIX_GENDER + "GENDER] " + "[" + PREFIX_GENDER + "MORE_GENDER] "
@@ -36,7 +36,9 @@ public class FindCommand extends Command {
             + "[" + PREFIX_TUTORIAL_GROUP + "TUTORIAL_GROUP] " + "[" + PREFIX_TUTORIAL_GROUP + "MORE_TUTORIAL_GROUPS] "
             + "[" + PREFIX_SOCIAL_HANDLE + "SOCIAL_HANDLE] " + "[" + PREFIX_SOCIAL_HANDLE + "MORE_SOCIAL_HANDLE] "
             + "[" + PREFIX_REMARK + "REMARK] " + "[" + PREFIX_REMARK + "MORE_REMARKS] "
-            + "[" + PREFIX_TAG + "TAG] " + "[" + PREFIX_TAG + "MORE_TAGS]...\n "
+            + "[" + PREFIX_TAG + "TAG] " + "[" + PREFIX_TAG + "MORE_TAGS]...\n"
+            + "Note: \n"
+            + " - Keywords are case-insensitive."
             + "Example: " + COMMAND_WORD + " n/alice g/f p/91234567 tg/19";
 
     private Predicate<Person> predicate;

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -26,7 +26,7 @@ public class ImportCommand extends Command {
     public static final String COMMAND_WORD = "import";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Imports a file identified by the given filename.\n"
+            + ": Imports the contacts list from a file identified by the given filename.\n"
             + "Parameters: FILENAME\n"
             + "Example: " + COMMAND_WORD + " t35.json";
 

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
@@ -21,12 +22,12 @@ public class RemarkCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Edits the remark of the person identified "
-            + "by the index number used in the last person listing. "
-            + "Existing remark will be overwritten by the input.\n"
+            + "by the index number used in the displayed person list. "
+            + "Existing remark will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "r/ [REMARK]\n"
+            + "[" + PREFIX_REMARK + "REMARK]\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + "r/Likes to swim.";
+            + "r/Likes to swim";
 
     public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to Person: %1$s";
     public static final String MESSAGE_DELETE_REMARK_SUCCESS = "Removed remark from Person: %1$s";

--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -26,8 +26,8 @@ public class SortCommand extends Command {
     public static final String COMMAND_WORD = "sort";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Sorts the contacts by a single chosen property in ascending order.\n"
-            + "Parameters: - \n"
+            + ": Sorts all contacts by a specified property in ascending order.\n"
+            + "Parameters: \n"
             + "[" + PREFIX_NAME + "] "
             + "[" + PREFIX_GENDER + "] "
             + "[" + PREFIX_PHONE + "] "

--- a/src/main/java/seedu/address/logic/commands/StatisticsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/StatisticsCommand.java
@@ -44,7 +44,7 @@ public class StatisticsCommand extends Command {
         requireNonNull(model);
 
         model.updateFilteredPersonList(p -> p.getTutorialGroup().equals(tutorialGroup));
-        List<Person> filteredPersonList = new ArrayList<Person>(model.getFilteredPersonList());
+        List<Person> filteredPersonList = new ArrayList<>(model.getFilteredPersonList());
         if (filteredPersonList.size() == 0) {
             throw new CommandException(MESSAGE_TUTORIAL_GROUP_NOT_FOUND);
         }
@@ -52,7 +52,7 @@ public class StatisticsCommand extends Command {
 
         Statistic statistic = new Statistic(filteredPersonList);
 
-        return new CommandResult(String.format(MESSAGE_STATISTICS, statistic.toString()), statistic.getRawData());
+        return new CommandResult(String.format(MESSAGE_STATISTICS, statistic), statistic.getRawData());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/DeleteMultipleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMultipleCommandParser.java
@@ -3,9 +3,12 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GENDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NATIONALITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_SOCIAL_HANDLE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TUTORIAL_GROUP;
 
@@ -15,13 +18,17 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.DeleteMultipleCommand;
+import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.predicate.EmailContainsKeywordsPredicate;
+import seedu.address.model.person.predicate.GenderContainsKeywordsPredicate;
 import seedu.address.model.person.predicate.MultiplePredicates;
 import seedu.address.model.person.predicate.NameContainsKeywordsPredicate;
 import seedu.address.model.person.predicate.NationalityContainsKeywordsPredicate;
 import seedu.address.model.person.predicate.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.predicate.RemarkContainsKeywordsPredicate;
+import seedu.address.model.person.predicate.SocialHandleContainsKeywordsPredicate;
 import seedu.address.model.person.predicate.TagContainsKeywordsPredicate;
 import seedu.address.model.person.predicate.TutorialGroupContainsKeywordsPredicate;
 
@@ -40,74 +47,132 @@ public class DeleteMultipleCommandParser implements Parser<DeleteMultipleCommand
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(
-                        args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NATIONALITY,
-                        PREFIX_TUTORIAL_GROUP, PREFIX_TAG);
+                        args, PREFIX_NAME, PREFIX_GENDER, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_NATIONALITY,
+                        PREFIX_TUTORIAL_GROUP, PREFIX_SOCIAL_HANDLE, PREFIX_REMARK, PREFIX_TAG);
 
         ArrayList<Predicate<Person>> predicateList = new ArrayList<>();
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()
                 && !argMultimap.getValue(PREFIX_NAME).get().trim().isEmpty()) {
             List<String> nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
+            for (String name : nameKeywords) {
+                ParserUtil.parseName(name);
+            }
             int numOfEmptyValue = nameKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
             }
             predicateList.add(new NameContainsKeywordsPredicate(nameKeywords));
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()
                 && !argMultimap.getValue(PREFIX_PHONE).get().trim().isEmpty()) {
             List<String> phoneKeywords = argMultimap.getAllValues(PREFIX_PHONE);
+            for (String phone : phoneKeywords) {
+                ParserUtil.parsePhone(phone);
+            }
             int numOfEmptyValue = phoneKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
             }
             predicateList.add(new PhoneContainsKeywordsPredicate(phoneKeywords));
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()
                 && !argMultimap.getValue(PREFIX_EMAIL).get().trim().isEmpty()) {
             List<String> emailKeywords = argMultimap.getAllValues(PREFIX_EMAIL);
+            for (String email : emailKeywords) {
+                ParserUtil.parseEmail(email);
+            }
             int numOfEmptyValue = emailKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
             }
             predicateList.add(new EmailContainsKeywordsPredicate(emailKeywords));
+        }
+        if (argMultimap.getValue(PREFIX_GENDER).isPresent()
+                && !argMultimap.getValue(PREFIX_GENDER).get().trim().isEmpty()) {
+            List<String> genderKeywords = argMultimap.getAllValues(PREFIX_GENDER);
+            for (String gender : genderKeywords) {
+                ParserUtil.parseGender(gender);
+            }
+            int numOfEmptyValue = genderKeywords.stream()
+                    .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
+            if (numOfEmptyValue != 0) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+            predicateList.add(new GenderContainsKeywordsPredicate(genderKeywords));
         }
         if (argMultimap.getValue(PREFIX_NATIONALITY).isPresent()
                 && !argMultimap.getValue(PREFIX_NATIONALITY).get().trim().isEmpty()) {
             List<String> nationalityKeywords = argMultimap.getAllValues(PREFIX_NATIONALITY);
+            for (String nationality : nationalityKeywords) {
+                ParserUtil.parseName(nationality);
+            }
             int numOfEmptyValue = nationalityKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
             }
             predicateList.add(new NationalityContainsKeywordsPredicate(nationalityKeywords));
         }
         if (argMultimap.getValue(PREFIX_TUTORIAL_GROUP).isPresent()
                 && !argMultimap.getValue(PREFIX_TUTORIAL_GROUP).get().trim().isEmpty()) {
             List<String> tutorialGroupKeywords = argMultimap.getAllValues(PREFIX_TUTORIAL_GROUP);
+            for (String tutorialGroup : tutorialGroupKeywords) {
+                ParserUtil.parseName(tutorialGroup);
+            }
             int numOfEmptyValue = tutorialGroupKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
             }
             predicateList.add(new TutorialGroupContainsKeywordsPredicate(tutorialGroupKeywords));
+        }
+        if (argMultimap.getValue(PREFIX_SOCIAL_HANDLE).isPresent()
+                && !argMultimap.getValue(PREFIX_SOCIAL_HANDLE).get().trim().isEmpty()) {
+            List<String> socialHandleKeywords = argMultimap.getAllValues(PREFIX_SOCIAL_HANDLE);
+            for (String socialHandle : socialHandleKeywords) {
+                ParserUtil.parseName(socialHandle);
+            }
+            int numOfEmptyValue = socialHandleKeywords.stream()
+                    .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
+            if (numOfEmptyValue != 0) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+            predicateList.add(new SocialHandleContainsKeywordsPredicate(socialHandleKeywords));
+        }
+        if (argMultimap.getValue(PREFIX_REMARK).isPresent()
+                && !argMultimap.getValue(PREFIX_REMARK).get().trim().isEmpty()) {
+            List<String> remarkKeywords = argMultimap.getAllValues(PREFIX_REMARK);
+            for (String remark : remarkKeywords) {
+                ParserUtil.parseName(remark);
+            }
+            int numOfEmptyValue = remarkKeywords.stream()
+                    .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
+            if (numOfEmptyValue != 0) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+            predicateList.add(new RemarkContainsKeywordsPredicate(remarkKeywords));
         }
         if (argMultimap.getValue(PREFIX_TAG).isPresent()
                 && !argMultimap.getValue(PREFIX_TAG).get().trim().isEmpty()) {
             List<String> tagKeywords = argMultimap.getAllValues(PREFIX_TAG);
+            ParserUtil.parseTags(tagKeywords);
             int numOfEmptyValue = tagKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
             }
             predicateList.add(new TagContainsKeywordsPredicate(tagKeywords));
         }
@@ -123,5 +188,6 @@ public class DeleteMultipleCommandParser implements Parser<DeleteMultipleCommand
             return new DeleteMultipleCommand(predicate);
         }
     }
+
 }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteMultipleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMultipleCommandParser.java
@@ -18,7 +18,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.DeleteMultipleCommand;
-import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.predicate.EmailContainsKeywordsPredicate;
@@ -62,7 +61,7 @@ public class DeleteMultipleCommandParser implements Parser<DeleteMultipleCommand
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
             }
             predicateList.add(new NameContainsKeywordsPredicate(nameKeywords));
         }
@@ -76,7 +75,7 @@ public class DeleteMultipleCommandParser implements Parser<DeleteMultipleCommand
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
             }
             predicateList.add(new PhoneContainsKeywordsPredicate(phoneKeywords));
         }
@@ -90,7 +89,7 @@ public class DeleteMultipleCommandParser implements Parser<DeleteMultipleCommand
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
             }
             predicateList.add(new EmailContainsKeywordsPredicate(emailKeywords));
         }
@@ -104,7 +103,7 @@ public class DeleteMultipleCommandParser implements Parser<DeleteMultipleCommand
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
             }
             predicateList.add(new GenderContainsKeywordsPredicate(genderKeywords));
         }
@@ -118,7 +117,7 @@ public class DeleteMultipleCommandParser implements Parser<DeleteMultipleCommand
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
             }
             predicateList.add(new NationalityContainsKeywordsPredicate(nationalityKeywords));
         }
@@ -132,7 +131,7 @@ public class DeleteMultipleCommandParser implements Parser<DeleteMultipleCommand
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
             }
             predicateList.add(new TutorialGroupContainsKeywordsPredicate(tutorialGroupKeywords));
         }
@@ -146,7 +145,7 @@ public class DeleteMultipleCommandParser implements Parser<DeleteMultipleCommand
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
             }
             predicateList.add(new SocialHandleContainsKeywordsPredicate(socialHandleKeywords));
         }
@@ -160,7 +159,7 @@ public class DeleteMultipleCommandParser implements Parser<DeleteMultipleCommand
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
             }
             predicateList.add(new RemarkContainsKeywordsPredicate(remarkKeywords));
         }
@@ -172,7 +171,7 @@ public class DeleteMultipleCommandParser implements Parser<DeleteMultipleCommand
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
                 throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMultipleCommand.MESSAGE_USAGE));
             }
             predicateList.add(new TagContainsKeywordsPredicate(tagKeywords));
         }

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -14,6 +14,9 @@ public class ExportCommandParser implements Parser<ExportCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ExportCommand parse(String args) throws ParseException {
+        if (args.trim().isEmpty()) {
+            throw new ParseException(ExportCommand.MESSAGE_USAGE);
+        }
         return new ExportCommand(args.trim());
     }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -54,6 +54,9 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (argMultimap.getValue(PREFIX_NAME).isPresent()
             && !argMultimap.getValue(PREFIX_NAME).get().trim().isEmpty()) {
             List<String> nameKeywords = argMultimap.getAllValues(PREFIX_NAME);
+            for (String name : nameKeywords) {
+                ParserUtil.parseName(name);
+            }
             int numOfEmptyValue = nameKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
@@ -65,6 +68,9 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()
             && !argMultimap.getValue(PREFIX_PHONE).get().trim().isEmpty()) {
             List<String> phoneKeywords = argMultimap.getAllValues(PREFIX_PHONE);
+            for (String phone : phoneKeywords) {
+                ParserUtil.parsePhone(phone);
+            }
             int numOfEmptyValue = phoneKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
@@ -76,6 +82,9 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()
             && !argMultimap.getValue(PREFIX_EMAIL).get().trim().isEmpty()) {
             List<String> emailKeywords = argMultimap.getAllValues(PREFIX_EMAIL);
+            for (String email : emailKeywords) {
+                ParserUtil.parseEmail(email);
+            }
             int numOfEmptyValue = emailKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
@@ -87,6 +96,9 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (argMultimap.getValue(PREFIX_GENDER).isPresent()
                 && !argMultimap.getValue(PREFIX_GENDER).get().trim().isEmpty()) {
             List<String> genderKeywords = argMultimap.getAllValues(PREFIX_GENDER);
+            for (String gender : genderKeywords) {
+                ParserUtil.parseGender(gender);
+            }
             int numOfEmptyValue = genderKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
@@ -98,6 +110,9 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (argMultimap.getValue(PREFIX_NATIONALITY).isPresent()
             && !argMultimap.getValue(PREFIX_NATIONALITY).get().trim().isEmpty()) {
             List<String> nationalityKeywords = argMultimap.getAllValues(PREFIX_NATIONALITY);
+            for (String nationality : nationalityKeywords) {
+                ParserUtil.parseName(nationality);
+            }
             int numOfEmptyValue = nationalityKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
@@ -109,6 +124,9 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (argMultimap.getValue(PREFIX_TUTORIAL_GROUP).isPresent()
             && !argMultimap.getValue(PREFIX_TUTORIAL_GROUP).get().trim().isEmpty()) {
             List<String> tutorialGroupKeywords = argMultimap.getAllValues(PREFIX_TUTORIAL_GROUP);
+            for (String tutorialGroup : tutorialGroupKeywords) {
+                ParserUtil.parseName(tutorialGroup);
+            }
             int numOfEmptyValue = tutorialGroupKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
@@ -120,6 +138,9 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (argMultimap.getValue(PREFIX_SOCIAL_HANDLE).isPresent()
                 && !argMultimap.getValue(PREFIX_SOCIAL_HANDLE).get().trim().isEmpty()) {
             List<String> socialHandleKeywords = argMultimap.getAllValues(PREFIX_SOCIAL_HANDLE);
+            for (String socialHandle : socialHandleKeywords) {
+                ParserUtil.parseName(socialHandle);
+            }
             int numOfEmptyValue = socialHandleKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
@@ -131,6 +152,9 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (argMultimap.getValue(PREFIX_REMARK).isPresent()
                 && !argMultimap.getValue(PREFIX_REMARK).get().trim().isEmpty()) {
             List<String> remarkKeywords = argMultimap.getAllValues(PREFIX_REMARK);
+            for (String remark : remarkKeywords) {
+                ParserUtil.parseName(remark);
+            }
             int numOfEmptyValue = remarkKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {
@@ -142,6 +166,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (argMultimap.getValue(PREFIX_TAG).isPresent()
             && !argMultimap.getValue(PREFIX_TAG).get().trim().isEmpty()) {
             List<String> tagKeywords = argMultimap.getAllValues(PREFIX_TAG);
+            ParserUtil.parseTags(tagKeywords);
             int numOfEmptyValue = tagKeywords.stream()
                     .filter(item-> item.isEmpty()).collect(Collectors.toList()).size();
             if (numOfEmptyValue != 0) {

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -14,6 +14,9 @@ public class ImportCommandParser implements Parser<ImportCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ImportCommand parse(String args) throws ParseException {
+        if (args.trim().isEmpty()) {
+            throw new ParseException(ImportCommand.MESSAGE_USAGE);
+        }
         return new ImportCommand(args.trim());
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -36,6 +36,10 @@ public class ParserUtil {
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
+            if (trimmedIndex.matches("\\d*[1-9]d*")) { // Number of any length, but must not be all 0s.
+                // assume the total number of users is less than 2.147 billion.
+                return Index.fromOneBased(Integer.MAX_VALUE);
+            }
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));

--- a/src/main/java/seedu/address/logic/parser/StatisticsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StatisticsCommandParser.java
@@ -15,9 +15,10 @@ public class StatisticsCommandParser implements Parser<StatisticsCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public StatisticsCommand parse(String args) throws ParseException {
-        if (args.trim().isEmpty()) {
-            throw new ParseException(StatisticsCommand.MESSAGE_USAGE);
+        if (args.trim().isEmpty() || !args.matches(TutorialGroup.VALIDATION_REGEX)) {
+            throw new ParseException(TutorialGroup.MESSAGE_CONSTRAINTS);
         }
+
         TutorialGroup tutorialGroup = ParserUtil.parseTutorialGroup(args.trim().toUpperCase());
         return new StatisticsCommand(tutorialGroup);
     }

--- a/src/main/java/seedu/address/logic/parser/StatisticsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StatisticsCommandParser.java
@@ -15,6 +15,9 @@ public class StatisticsCommandParser implements Parser<StatisticsCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public StatisticsCommand parse(String args) throws ParseException {
+        if (args.trim().isEmpty()) {
+            throw new ParseException(StatisticsCommand.MESSAGE_USAGE);
+        }
         TutorialGroup tutorialGroup = ParserUtil.parseTutorialGroup(args.trim().toUpperCase());
         return new StatisticsCommand(tutorialGroup);
     }

--- a/src/main/java/seedu/address/logic/parser/StatisticsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/StatisticsCommandParser.java
@@ -15,7 +15,7 @@ public class StatisticsCommandParser implements Parser<StatisticsCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public StatisticsCommand parse(String args) throws ParseException {
-        if (args.trim().isEmpty() || !args.matches(TutorialGroup.VALIDATION_REGEX)) {
+        if (args.trim().isEmpty() || !args.trim().matches(TutorialGroup.VALIDATION_REGEX)) {
             throw new ParseException(TutorialGroup.MESSAGE_CONSTRAINTS);
         }
 


### PR DESCRIPTION
**Issue #217 :**
All commands which involves the parsing of Index will return an Invalid Command Format when a Non-Zero Integer cannot be parsed.

According to @xianlinc, the correct error should be 'The person index provided is invalid', no matter how large the input number. [Valid point]

I've added a check, such that all strings that
1. Contains just numbers AND
2. Not the integer range (i.e between -2 billion to 2 billion) AND
3. Is a positive number (any length), but must not be all 0s...
will return an Index with value of Integer.MAX_INT.

This assumes that the users will not have 2.147 billion friends in Socius, which should be a reasonable assumption to make (Consider the size of json file and time taken to import!!)

**Issue #209 :**
"Invalid Command Format" is returned when non-positive integer is entered as Index.

According to @xianlinc, the correct error should be 'The person index provided is invalid', no matter whether the number is valid. [While I understand the concern, I disagree with the conclusion. It is already said in the UG that Index must be a positive integer. Violating this constraint is firstly an invalid Command that cannot be parsed, instead of an invalid Index]

I think we can close that issue.

Small Bug Fixes:
1. Standardise the format of Message_Usage for all commands.
2. Update the descriptions of some Message_Usage for better clarity.
3. Support Gender, Remark and SocialHandles properties for DeleteMultiple Command.
4. Check correctness of input for DeleteMultiple and FindCommand
5. Prevent users for inputting only '.json' in ImportCommand and ExportCommand.
6. Throws an ParseException for invalid tutorial group format for Statistics Command

